### PR TITLE
Move TypeScript to devDependencies

### DIFF
--- a/authentication-typescript/CHANGELOG.md
+++ b/authentication-typescript/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Support for IE11.
 
+### Changed
+
+-   Moved TypeScript to devDependencies.
+
 ## v1.0.1
 
 ### Fixed

--- a/authentication-typescript/template.json
+++ b/authentication-typescript/template.json
@@ -13,11 +13,11 @@
             "react-i18next": "^11.7.0",
             "react-router": "^5.2.0",
             "react-router-dom": "^5.2.0",
-            "typescript": "^4.0.3",
             "web-vitals": "^0.2.4"
         },
         "devDependencies": {
             "enzyme": "^3.11.0",
+            "typescript": "^4.0.3",
             "@wojtekmaj/enzyme-adapter-react-17": "^0.6.0",
             "@testing-library/jest-dom": "^5.11.4",
             "@testing-library/react": "^11.2.5",

--- a/blank-typescript/CHANGELOG.md
+++ b/blank-typescript/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Support for IE11.
 
+### Changed
+
+-   Moved TypeScript to devDependencies.
+
 ## 1.0.0
 
 ### Added

--- a/blank-typescript/template.json
+++ b/blank-typescript/template.json
@@ -8,11 +8,11 @@
             "@pxblue/icons-mui": "^2.3.0",
             "@pxblue/colors": "^3.0.0",
             "react-app-polyfill": "latest",
-            "typescript": "^4.0.3",
             "web-vitals": "^0.2.4"
         },
         "devDependencies": {
             "enzyme": "^3.11.0",
+            "typescript": "^4.0.3",
             "@wojtekmaj/enzyme-adapter-react-17": "^0.6.0",
             "@testing-library/jest-dom": "^5.11.4",
             "@testing-library/react": "^11.2.5",

--- a/routing-typescript/CHANGELOG.md
+++ b/routing-typescript/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Support for IE11.
 
+### Changed
+
+-   Moved TypeScript to devDependencies.
+
 ## v1.0.0
 
 ### Added

--- a/routing-typescript/template.json
+++ b/routing-typescript/template.json
@@ -10,11 +10,11 @@
             "react-app-polyfill": "latest",
             "react-router": "^5.2.0",
             "react-router-dom": "^5.2.0",
-            "typescript": "^4.0.3",
             "web-vitals": "^0.2.4"
         },
         "devDependencies": {
             "enzyme": "^3.11.0",
+            "typescript": "^4.0.3",
             "@wojtekmaj/enzyme-adapter-react-17": "^0.6.0",
             "@testing-library/jest-dom": "^5.11.4",
             "@testing-library/react": "^11.2.5",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #16 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Move typescript to devDependencies
- All three ts templates have been tested with `npx create-react-app` locally and they spinned up projects without a problem. No duplicated packages are seen in their generated `package.json`'s.

