### PR TITLE
remove px blue ref

### DIFF
--- a/authentication-typescript/template/src/App.test.tsx
+++ b/authentication-typescript/template/src/App.test.tsx
@@ -25,6 +25,6 @@ test('renders welcome text', () => {
             </DrawerContext.Provider>
         </ThemeProvider>
     );
-    const bluiText = screen.getByText(/Welcome to PX/i);
+    const bluiText = screen.getByText(/Welcome to Brightlayer/i);
     expect(bluiText).toBeInTheDocument();
 });

--- a/authentication-typescript/template/src/pages/home.tsx
+++ b/authentication-typescript/template/src/pages/home.tsx
@@ -122,9 +122,9 @@ export const HomePage = (): JSX.Element => {
                     <div style={{ textAlign: 'center' }}>
                         <BluiSVG className={classes.rotate} size={xs ? 100 : 160} color={theme.palette.primary.main} />
                         <Typography variant={xs ? 'h4' : 'h2'} paragraph>
-                            Welcome to PX{' '}
+                            Welcome to Brightlayer{' '}
                             <Typography variant={'inherit'} color={'primary'}>
-                                Blue
+                                UI
                             </Typography>
                             .
                         </Typography>

--- a/authentication/template/src/App.test.jsx
+++ b/authentication/template/src/App.test.jsx
@@ -25,6 +25,6 @@ test('renders welcome text', () => {
             </DrawerContext.Provider>
         </ThemeProvider>
     );
-    const bluiText = screen.getByText(/Welcome to PX/i);
+    const bluiText = screen.getByText(/Welcome to Brightlayer/i);
     expect(bluiText).toBeInTheDocument();
 });

--- a/authentication/template/src/pages/home.jsx
+++ b/authentication/template/src/pages/home.jsx
@@ -121,9 +121,9 @@ export const HomePage = () => {
                     <div style={{ textAlign: 'center' }}>
                         <BluiSVG className={classes.rotate} size={xs ? 100 : 160} color={theme.palette.primary.main} />
                         <Typography variant={xs ? 'h4' : 'h2'} paragraph>
-                            Welcome to PX{' '}
+                            Welcome to Brightlayer{' '}
                             <Typography variant={'inherit'} color={'primary'}>
-                                Blue
+                                UI
                             </Typography>
                             .
                         </Typography>

--- a/blank-typescript/template/src/App.test.tsx
+++ b/blank-typescript/template/src/App.test.tsx
@@ -4,6 +4,6 @@ import { App } from './App';
 
 test('renders lwelcome text', () => {
     render(<App />);
-    const bluiText = screen.getByText(/Welcome to PX/i);
+    const bluiText = screen.getByText(/Welcome to Brightlayer/i);
     expect(bluiText).toBeInTheDocument();
 });

--- a/blank-typescript/template/src/App.tsx
+++ b/blank-typescript/template/src/App.tsx
@@ -72,9 +72,9 @@ export const App = (): JSX.Element => {
                     <div style={{ textAlign: 'center' }}>
                         <BluiSVG className={classes.rotate} size={xs ? 100 : 160} color={theme.palette.primary.main} />
                         <Typography variant={xs ? 'h4' : 'h2'} paragraph>
-                            Welcome to PX{' '}
+                            Welcome to Brightlayer{' '}
                             <Typography variant={'inherit'} color={'primary'}>
-                                Blue
+                                UI
                             </Typography>
                             .
                         </Typography>

--- a/blank/template/src/App.jsx
+++ b/blank/template/src/App.jsx
@@ -71,9 +71,9 @@ export const App = () => {
                     <div style={{ textAlign: 'center' }}>
                         <BluiSVG className={classes.rotate} size={xs ? 100 : 160} color={theme.palette.primary.main} />
                         <Typography variant={xs ? 'h4' : 'h2'} paragraph>
-                            Welcome to PX{' '}
+                            Welcome to Brightlayer{' '}
                             <Typography variant={'inherit'} color={'primary'}>
-                                Blue
+                                UI
                             </Typography>
                             .
                         </Typography>

--- a/blank/template/src/App.test.jsx
+++ b/blank/template/src/App.test.jsx
@@ -4,6 +4,6 @@ import { App } from './App';
 
 test('renders welcome text', () => {
     render(<App />);
-    const bluiText = screen.getByText(/Welcome to PX/i);
+    const bluiText = screen.getByText(/Welcome to Brightlayer/i);
     expect(bluiText).toBeInTheDocument();
 });

--- a/routing-typescript/template/src/App.test.tsx
+++ b/routing-typescript/template/src/App.test.tsx
@@ -18,6 +18,6 @@ test('renders welcome text', () => {
             </DrawerContext.Provider>
         </ThemeProvider>
     );
-    const bluiText = screen.getByText(/Welcome to PX/i);
+    const bluiText = screen.getByText(/Welcome to Brightlayer/i);
     expect(bluiText).toBeInTheDocument();
 });

--- a/routing-typescript/template/src/pages/home.tsx
+++ b/routing-typescript/template/src/pages/home.tsx
@@ -86,9 +86,9 @@ export const HomePage = (): JSX.Element => {
                     <div style={{ textAlign: 'center' }}>
                         <BluiSVG className={classes.rotate} size={xs ? 100 : 160} color={theme.palette.primary.main} />
                         <Typography variant={xs ? 'h4' : 'h2'} paragraph>
-                            Welcome to PX{' '}
+                            Welcome to Brightlayer{' '}
                             <Typography variant={'inherit'} color={'primary'}>
-                                Blue
+                                UI
                             </Typography>
                             .
                         </Typography>

--- a/routing/template/src/App.test.jsx
+++ b/routing/template/src/App.test.jsx
@@ -18,6 +18,6 @@ test('renders welcome text', () => {
             </DrawerContext.Provider>
         </ThemeProvider>
     );
-    const bluiText = screen.getByText(/Welcome to PX/i);
+    const bluiText = screen.getByText(/Welcome to Brightlayer/i);
     expect(bluiText).toBeInTheDocument();
 });

--- a/routing/template/src/pages/home.jsx
+++ b/routing/template/src/pages/home.jsx
@@ -85,9 +85,9 @@ export const HomePage = () => {
                     <div style={{ textAlign: 'center' }}>
                         <BluiSVG className={classes.rotate} size={xs ? 100 : 160} color={theme.palette.primary.main} />
                         <Typography variant={xs ? 'h4' : 'h2'} paragraph>
-                            Welcome to PX{' '}
+                            Welcome to Brightlayer{' '}
                             <Typography variant={'inherit'} color={'primary'}>
-                                Blue
+                                UI
                             </Typography>
                             .
                         </Typography>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
React CLI Templates:

1. Authentication  Template:
<img width="1792" alt="app_auth" src="https://user-images.githubusercontent.com/10433274/145040835-351f0de5-0374-4155-9b88-a3d7a92c7450.png">

2. Authentication Typescript Template:
<img width="1469" alt="aap_auth_type" src="https://user-images.githubusercontent.com/10433274/145040928-6ec2f70f-810b-45c8-b088-31d7be543583.png">

3. Blank Template:
<img width="1269" alt="app_blank" src="https://user-images.githubusercontent.com/10433274/145040968-e37799e0-40ec-4592-9801-37e949d1eb64.png">

4. Blank Typescript Template
<img width="1423" alt="app_blank_type" src="https://user-images.githubusercontent.com/10433274/145041009-d7fa0907-5b5b-4268-8077-ff3e7c0925c6.png">
:
